### PR TITLE
Update push gateway response code

### DIFF
--- a/src/Prometheus/PushGateway.php
+++ b/src/Prometheus/PushGateway.php
@@ -82,7 +82,7 @@ class PushGateway
         }
         $response = $client->request($method, $url, $requestOptions);
         $statusCode = $response->getStatusCode();
-        if ($statusCode != 202) {
+        if (!in_array($statusCode, [200, 202])) {
             $msg = "Unexpected status code " . $statusCode . " received from pushgateway " . $this->address . ": " . $response->getBody();
             throw new \RuntimeException($msg);
         }


### PR DESCRIPTION
Updates the expected push gateway response to accept `200` http status.
This solves the issue with the `Unexpected status code`  exception, while keeping compatibility with the older version.